### PR TITLE
Allow underscores in UMIs as well since FastP includes them

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -259,7 +259,12 @@ pub fn isbase(b: &u8) -> bool {
 fn umi_from_readname(r: &[u8]) -> Option<(&[u8], &[u8])> {
     if let Some(lastcolon) = r.iter().rev().position(|&c| c == b':') {
         let pos = r.len() - lastcolon;
-        if lastcolon >= 3 && r[pos..].iter().filter(|&&c| c != b'+').all(isbase) {
+        if lastcolon >= 3
+            && r[pos..]
+                .iter()
+                .filter(|&&c| c != b'+' && c != b'_')
+                .all(isbase)
+        {
             let umi = &r[pos..];
             let clipped = &r[0..pos - 1];
             return Some((umi, clipped));
@@ -317,6 +322,14 @@ mod test {
             umi_from_readname(&b"A01260:10:HWNYWDRXX:1:1273:8205:25198:CGACC+TAGNA"[..]),
             Some((
                 &b"CGACC+TAGNA"[..],
+                &b"A01260:10:HWNYWDRXX:1:1273:8205:25198"[..]
+            ))
+        );
+
+        assert_eq!(
+            umi_from_readname(&b"A01260:10:HWNYWDRXX:1:1273:8205:25198:CGACC_TAGNA"[..]),
+            Some((
+                &b"CGACC_TAGNA"[..],
                 &b"A01260:10:HWNYWDRXX:1:1273:8205:25198"[..]
             ))
         );


### PR DESCRIPTION
> I'm very curious to hear if you can process your dataset. Feel free to file an issue if it doesn't work!

As outlined in #7, I revisited `rumidup` to troubleshoot an unusual sequencing run that brought both `umi-tools dedup` and `UMICollapse` to their knees.

I'm pleased to report that `rumidup` successfully processed these problematic files within a relatively short timeframe — approximately a couple of minutes per file. While I did not monitor memory consumption, the process completed successfully with 128GB available, apparently sufficient for the task.

Only one small adjustment was necessary:  I had to permit underscores in UMIs, since [FastP](https://github.com/OpenGene/fastp?tab=readme-ov-file#unique-molecular-identifier-umi-processing) includes them, seemingly without the option for customization. The files were preprocessed with `fastp ... --umi --umi_loc=per_read --umi_len=5 --umi_skip=2` and I could not find an argument that would allow customizing the separator, for example, to the permissible `+` character.

While I have not deeply examined the underlying data structures and deduplication logic to exhaustively validate this change, at least the distance calculation function appears unaffected, if I understand it correctly. 

> Awesome! The code test coverage is going to be pretty abysmal, but it will surely help us in pushing for a proper release. We actually are quite happy with the tool and use it in many production runs internally.

Indeed, a seemingly solid tool with a neat algorithm. If I may suggest one more feature prior to release, it would be the option to provide a `sample ID` via a dedicated CLI argument, that is included in an alternative, JSON-formatted version of the metrics. JSON-metrics that include a customizable sample ID can be easily parsed and aggregated with [MultiQC](https://seqera.io/multiqc/). Since we use that approach a lot in nf-core, that would be very handy for the broader adoption of your tool.

Please feel free to copy and adapt what you need from [the umi-transfer integration tests](https://github.com/SciLifeLab/umi-transfer/tree/main/tests). It indeed took me some effort to set them up, but I now cobbled something together that is able to test CLI arguments, can use sample data files and validate output file contents. The biggest challenge was finding a way to test for interactive prompts shown to the user with some delay - [but that now works as well](https://github.com/SciLifeLab/umi-transfer/blob/ed0f04e6a50bfd34424d5a39f867c4b545dc2fbe/tests/integration_tests_external.rs#L210). 